### PR TITLE
feat(auth) add mustChangePassword as new parameter

### DIFF
--- a/src/main/java/com/ironcore/application/auth/port/AccessTokenSubject.java
+++ b/src/main/java/com/ironcore/application/auth/port/AccessTokenSubject.java
@@ -5,6 +5,7 @@ import com.ironcore.domain.user.valueobject.UserId;
 
 public record AccessTokenSubject(
         UserId userId,
-        Email email
+        Email email,
+        Boolean mustChangePassword
 ) {
 }

--- a/src/main/java/com/ironcore/application/auth/usecase/LoginUseCase.java
+++ b/src/main/java/com/ironcore/application/auth/usecase/LoginUseCase.java
@@ -37,7 +37,7 @@ public class LoginUseCase {
         }
 
         GeneratedAccessToken accessToken = accessTokenGenerator.generate(
-                new AccessTokenSubject(user.getId(), user.getEmail())
+                new AccessTokenSubject(user.getId(), user.getEmail(), user.mustChangePassword())
         );
 
         return new LoginResult(

--- a/src/main/java/com/ironcore/infrastructure/security/jwt/JwtAccessTokenGenerator.java
+++ b/src/main/java/com/ironcore/infrastructure/security/jwt/JwtAccessTokenGenerator.java
@@ -40,6 +40,7 @@ public class JwtAccessTokenGenerator implements AccessTokenGenerator {
                 .withIssuer(properties.getIssuer())
                 .withSubject(String.valueOf(subject.userId().value()))
                 .withClaim("email", subject.email().value())
+                .withClaim("mustChangePassword", subject.mustChangePassword())
                 .withExpiresAt(Date.from(expiresAt.atZone(zoneId).toInstant()))
                 .sign(Algorithm.HMAC256(properties.getSecret()));
 

--- a/src/test/java/com/ironcore/application/auth/usecase/LoginUseCaseTest.java
+++ b/src/test/java/com/ironcore/application/auth/usecase/LoginUseCaseTest.java
@@ -55,7 +55,11 @@ class LoginUseCaseTest {
                     .thenReturn(Optional.of(user));
             when(passwordHashingService.matches(new RawPassword(command.rawPassword()), user.getPasswordHash()))
                     .thenReturn(true);
-            when(accessTokenGenerator.generate(new AccessTokenSubject(user.getId(), user.getEmail())))
+            when(accessTokenGenerator.generate(new AccessTokenSubject(
+                    user.getId(),
+                    user.getEmail(),
+                    user.mustChangePassword()))
+            )
                     .thenReturn(accessToken);
 
             LoginResult result = useCase.execute(command);
@@ -78,6 +82,7 @@ class LoginUseCaseTest {
 
             assertThat(subject.userId()).isEqualTo(user.getId());
             assertThat(subject.email()).isEqualTo(user.getEmail());
+            assertThat(subject.mustChangePassword()).isEqualTo(user.mustChangePassword());
         }
     }
 

--- a/src/test/java/com/ironcore/infrastructure/security/jwt/JwtAccessTokenGenerationTest.java
+++ b/src/test/java/com/ironcore/infrastructure/security/jwt/JwtAccessTokenGenerationTest.java
@@ -51,6 +51,7 @@ class JwtAccessTokenGenerationTest {
             assertThat(decodedJWT.getIssuer()).isEqualTo(ISSUER);
             assertThat(decodedJWT.getSubject()).isEqualTo("1");
             assertThat(decodedJWT.getClaim("email").asString()).isEqualTo("renan@example.com");
+            assertThat(decodedJWT.getClaim("mustChangePassword").asBoolean()).isTrue();
             assertThat(decodedJWT.getExpiresAt()).isNotNull();
         }
     }
@@ -91,7 +92,8 @@ class JwtAccessTokenGenerationTest {
     private AccessTokenSubject subject() {
         return new AccessTokenSubject(
                 new UserId(1L),
-                new Email("renan@example.com")
+                new Email("renan@example.com"),
+                true
         );
     }
 }


### PR DESCRIPTION
## Importante

Complementa a entrega anterior (#52) de autenticação adicionando a claim `mustChangePassword` ao JWT emitido, que havia ficado disponível apenas no `LoginResult`.

### Checklist

- [x]  Escopo atendido
- [x]  Código revisado
- [x]  Sem código comentado/desnecessário
- [x]  Sem breaking changes não intencionais